### PR TITLE
Fix match_badip regular expression.

### DIFF
--- a/sshscan.py
+++ b/sshscan.py
@@ -191,7 +191,7 @@ for line in rand_lines:
                 count_ips += 1
 
                 # Don't scan network and broadcast addresses
-                match_badip = re.search('\.0|255$', str(ip))
+                match_badip = re.search('\.(0|255)$', str(ip))
                 if match_badip:
                     continue
                 # If status is defined, we know the connection failed


### PR DESCRIPTION
The match_badip expression was matching addresses like 10.0.1.1, which should be valid. Now I can scan a range of IPs that have an octect of 0 somewhere in the address, like 10.0.1.1-10.0.1.50.